### PR TITLE
Make it work serverless

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ module.exports = (
 
       const { dev } = options;
       const { rules } = config.module;
+      const { target } = nextConfig;
 
       // -- module --
 
@@ -93,7 +94,7 @@ module.exports = (
       rules[1].oneOf.splice(sassModuleIndex, 0, lessModule);
       config.module.rules = rules;
 
-      config = handleAntdInServer(config, options);
+      config = handleAntdInServer(config, options, target);
 
       if (typeof nextConfig.webpack === 'function') return nextConfig.webpack(config, options);
 
@@ -102,10 +103,10 @@ module.exports = (
   };
 };
 
-function handleAntdInServer(config, options) {
+function handleAntdInServer(config, options, target) {
   if (!options.isServer) return config;
 
-  const ANTD_STYLE_REGX = /antd\/.*?\/style.*?/;
+  const ANTD_STYLE_REGX = target === 'serverless' ? /(antd\/.*?\/style).*(?<![.]js)$/ : /antd\/.*?\/style.*?/;
   const rawExternals = [...config.externals];
 
   config.externals = [


### PR DESCRIPTION
The serverless build will fail with error `TypeError: (0 , _styleChecker.isStyleSupport) is not a function`. I used a solution from this issue: https://github.com/vercel/next.js/issues/8151

I don't know how it would affect the server build if we use an extended regex without any conditions. At least it buildable :D So, I made the condition just in case.