### PR TITLE
optional cssLoaderOptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ module.exports = (
           // }
           //
           mode: 'local', // local, global, and pure, next.js default is `pure`
-          ...nextConfig.cssLoaderOptions.modules,
+          ...(nextConfig.cssLoaderOptions || {}).modules,
           auto: true, // keep true
         }
       };


### PR DESCRIPTION
So that we can use this plugin without providing `cssLoaderOptions` as empty object:

```js
// next.config.js
const withAntdLess = require("next-plugin-antd-less");

module.exports = withAntdLess({
  lessVarsFilePath: "./src/styles/variables.less",
});
```