### PR TITLE
fix(package.json): Adding missing required dependencies `less` and and `babel-plugin-import`

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
   ],
   "devDependencies": {},
   "dependencies": {
+    "babel-plugin-import": "^1.13.3",
     "clone": "^2.1.2",
+    "less": "^3.13.1",
     "less-loader": "^7.1.0",
     "less-vars-to-js": "^1.3.0",
     "null-loader": "^4.0.1"


### PR DESCRIPTION
Less version is kept on v3.x.x because of the required parens on mixins introduced by less v4.0.0.