### PR TITLE
fix: Make lessVarsFilePathAppendToEndOfContent not to include twice

### DIFF
--- a/overrideWebpackConfig.js
+++ b/overrideWebpackConfig.js
@@ -161,11 +161,11 @@ function overrideWebpackConfig({ webpackConfig, nextConfig, pluginOptions }) {
       if (fs.existsSync(lessVarsFileResolvePath)) {
         const importLessLine = `@import '${lessVarsFileResolvePath}';`
 
-        content = `${importLessLine};\n\n${content}`;
-
         // https://github.com/SolidZORO/next-plugin-antd-less/issues/40
         if (pluginOptions.lessVarsFilePathAppendToEndOfContent) {
           content = `${content}\n\n${importLessLine};`;
+        } else {
+          content = `${importLessLine};\n\n${content}`;
         }
 
         // console.log(content);


### PR DESCRIPTION
@SolidZORO,

Somehow less was "optimizing" double imports? The second import didn't seem to take any effect.

Had to do this to make it work for my use case.
