### PR TITLE
Fix for stylechecker null-loader

### DIFF
--- a/overrideWebpackConfig.js
+++ b/overrideWebpackConfig.js
@@ -283,7 +283,7 @@ function overrideWebpackConfig({ webpackConfig, nextConfig, pluginOptions }) {
 function handleAntdInServer(webpackConfig, nextConfig) {
   if (!nextConfig.isServer) return webpackConfig;
 
-  const ANTD_STYLE_REGX = /antd\/.*?\/style.*?/;
+  const ANTD_STYLE_REGX = /(antd\/.*?\/style).*(?<![.]js)$/;
   const rawExternals = [...webpackConfig.externals];
 
   webpackConfig.externals = [


### PR DESCRIPTION
Fixes issue when encountering:
```cli
> Build error occurred
TypeError: (0 , _styleChecker.isStyleSupport) is not a function
```

See: https://github.com/vercel/next.js/issues/8151#issuecomment-527385664