### PR TITLE
feat: support for antd-pro

### DIFF
--- a/overrideWebpackConfig.js
+++ b/overrideWebpackConfig.js
@@ -320,7 +320,8 @@ function isWebpack5(nextConfig) {
 function handleAntdInServer(webpackConfig, nextConfig) {
   if (!nextConfig.isServer) return webpackConfig;
 
-  const ANTD_STYLE_REGX = /(antd\/.*?\/style).*(?<![.]js)$/;
+  // 将正则条件放宽，同时匹配 antd 与 antd-pro
+  const ANTD_STYLE_REGX = /antd\/.*?\/style.*?/;
   const exts = [...webpackConfig.externals];
 
   webpackConfig.externals =


### PR DESCRIPTION
目前在 next 11 中 使用动态导入 加载 antd-pro 组件样式异常，放宽正则匹配规则后可以正常使用。