### PR TITLE
docs: Update Installation section in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Yep! this plugin supports both [Next.js] and [CRA] since v1.0.
 
 ```sh
 yarn add next-plugin-antd-less
+yarn add --dev babel-plugin-import
 ```
 
 


### PR DESCRIPTION
Updated Installation section in Readme, `babel-plugin-import` package should be installed