### PR TITLE
support for NextJs12

### DIFF
--- a/overrideWebpackConfig.js
+++ b/overrideWebpackConfig.js
@@ -20,7 +20,8 @@ function checkIsNextJs(webpackConfig) {
     webpackConfig &&
       webpackConfig.resolveLoader &&
       webpackConfig.resolveLoader.alias &&
-      webpackConfig.resolveLoader.alias['next-babel-loader'],
+      (webpackConfig?.resolveLoader?.alias['next-babel-loader'] ||
+        webpackConfig.resolveLoader.alias['next-swc-loader']),
   );
 }
 
@@ -195,7 +196,8 @@ function overrideWebpackConfig({ webpackConfig, nextConfig, pluginOptions }) {
     const noopLoader = rule.oneOf[noopLoaderIndex];
 
     if (noopLoader) {
-      noopLoader.test = /\.(css|scss|sass|less)(\.webpack\[javascript\/auto\])?$/;
+      noopLoader.test =
+        /\.(css|scss|sass|less)(\.webpack\[javascript\/auto\])?$/;
     }
   }
 


### PR DESCRIPTION
NextJs12 is released and checkIsNextJs function is false for the reason why it is not built.
Until version 11, the alias was "next-babel-loader", but as it goes up to version 12, it is changed to "next-swc-loader", and the content is added.